### PR TITLE
npm should publish `dist` files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+src
+test

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "vue-intl",
   "version": "0.0.1",
   "description": "Vue Plugin for FormatJS Internalization and Localization",
-  "main": "lib/vue_intl.js",
+  "main": "lib/vue-intl.js",
+  "files": ["dist"],
   "engines": {
     "node": ">=0.12.0"
   },


### PR DESCRIPTION
Currently the package on `https://www.npmjs.com/package/vue-intl` doesn't have the distribution files.

I followed [this advice](https://booker.codes/how-to-build-and-publish-es6-npm-modules-today-with-babel/), but haven't actually tested publishing.
