### PR TITLE
add FormattedMessage component

### DIFF
--- a/src/FormattedMessage.js
+++ b/src/FormattedMessage.js
@@ -1,0 +1,39 @@
+const format = (ctx, values) => ctx.parent.$formatMessage(ctx.props, values)
+const placeholder = (name) => `@\0@\0${name}\0@\0@`
+const placeholderRegex = /@\0@\0(.*?)\0@\0@/g
+
+export default {
+    functional: true,
+
+    props: {
+        id: {type: String, required: true},
+        defaultMessage: String,
+        values: Object,
+        tagName: {type: String, default: 'span'}
+    },
+
+    render (h, ctx) {
+        const slots = ctx.slots()
+        const slotNames = Object.keys(slots)
+        if (slotNames.length === 0) {
+            return h(ctx.props.tagName, ctx.data, format(ctx, ctx.props.values))
+        }
+
+        const values = Object.assign({}, ctx.props.values)
+        slotNames.forEach(slot => {
+            values[slot] = placeholder(slot)
+        })
+
+        const message = format(ctx, values)
+
+        let match;
+        let pos = 0;
+        const children = []
+        while ((match = placeholderRegex.exec(message)) !== null) {
+            children.push(message.substring(pos, match.index), slots[match[1]])
+            pos = match.index + match[0].length
+        }
+        children.push(message.substring(pos))
+        return h(ctx.props.tagName, ctx.data, children)
+    }
+}

--- a/src/vue-intl.js
+++ b/src/vue-intl.js
@@ -3,6 +3,8 @@ import setLocale from './setLocale';
 import getLocaleData from './getLocaleData';
 import state from './state';
 import * as formatMethods from './format';
+import FormattedMessage from './FormattedMessage'
+export { FormattedMessage }
 
 const VueIntl = {
     install(Vue, options={}) {


### PR DESCRIPTION
Added the implementation of FormattedMessage, solves #5 

Use like
```html
<FormattedMessage
  id="welcome"
  defaultMessage="Hello {name}, you have {count, number} {count, plural, one {message} other {messages}}"
  :values="{count: 15}">
  <strong slot="name">Tim</strong>
</FormattedMessage>
```

Generates
> Hello **Tim**, you have 15 messages

It's tested locally, but without unit tests as there is no dependency on Vue yet. Didn't wanted to change the testing config.